### PR TITLE
Fix dnsPolicy: not in block imagePullSecrets

### DIFF
--- a/perforator/deploy/kubernetes/helm/perforator/templates/agent/daemonset.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/templates/agent/daemonset.yaml
@@ -36,8 +36,8 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      dnsPolicy: {{ .Values.agent.dnsPolicy }}
       {{- end }}
+      dnsPolicy: {{ .Values.agent.dnsPolicy }}
       containers:
       - name: {{ include "perforator.fullname" . }}-agent
         image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"

--- a/perforator/deploy/kubernetes/helm/perforator/templates/gc/deployment.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/templates/gc/deployment.yaml
@@ -35,8 +35,8 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      dnsPolicy: {{ .Values.gc.dnsPolicy }}
       {{- end }}
+      dnsPolicy: {{ .Values.gc.dnsPolicy }}
       containers:
       - name: {{ include "perforator.fullname" . }}-gc
         image: "{{ .Values.gc.image.repository }}:{{ .Values.gc.image.tag | default .Chart.AppVersion }}"

--- a/perforator/deploy/kubernetes/helm/perforator/templates/offline-processing/deployment.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/templates/offline-processing/deployment.yaml
@@ -35,8 +35,8 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      dnsPolicy: {{ .Values.offlineprocessing.dnsPolicy }}
       {{- end }}
+      dnsPolicy: {{ .Values.offlineprocessing.dnsPolicy }}
       containers:
       - name: {{ include "perforator.fullname" . }}-offlineprocessing
         image: "{{ .Values.offlineprocessing.image.repository }}:{{ .Values.offlineprocessing.image.tag | default .Chart.AppVersion }}"

--- a/perforator/deploy/kubernetes/helm/perforator/templates/proxy/deployment.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/templates/proxy/deployment.yaml
@@ -35,8 +35,8 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      dnsPolicy: {{ .Values.proxy.dnsPolicy }}
       {{- end }}
+      dnsPolicy: {{ .Values.proxy.dnsPolicy }}
       containers:
       - name: {{ include "perforator.fullname" . }}-proxy
         image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag | default .Chart.AppVersion }}"

--- a/perforator/deploy/kubernetes/helm/perforator/templates/storage/deployment.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/templates/storage/deployment.yaml
@@ -35,8 +35,8 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      dnsPolicy: {{ .Values.storage.dnsPolicy }}
       {{- end }}
+      dnsPolicy: {{ .Values.storage.dnsPolicy }}
       containers:
       - name: {{ include "perforator.fullname" . }}-storage
         image: "{{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag | default .Chart.AppVersion }}"

--- a/perforator/deploy/kubernetes/helm/perforator/templates/web/deployment.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/templates/web/deployment.yaml
@@ -36,8 +36,8 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      dnsPolicy: {{ .Values.web.dnsPolicy }}
       {{- end }}
+      dnsPolicy: {{ .Values.web.dnsPolicy }}
       containers:
       - name: {{ include "perforator.fullname" . }}-web
         image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.

```
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       dnsPolicy: {{ .Values.proxy.dnsPolicy }}
       {{- end }}
```

It's invalid: Error: template: perforator/charts/perforator/templates/web/deployment.yaml:39:27: executing "perforator/charts/perforator/templates/web/deployment.yaml" at <.Values.web.dnsPolicy>: can't evaluate field Values in type []interface {}

This PR fix it.