### PR TITLE
fix: duplicated tls

### DIFF
--- a/perforator/deploy/kubernetes/helm/perforator/Chart.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/perforator/deploy/kubernetes/helm/perforator/templates/web/ingress-grpc.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/templates/web/ingress-grpc.yaml
@@ -53,14 +53,4 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
-  {{- if .Values.ingress.grpc.tls }}
-  tls:
-    {{- range .Values.ingress.grpc.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
 {{- end }}

--- a/perforator/deploy/kubernetes/helm/perforator/templates/web/ingress-http.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/templates/web/ingress-http.yaml
@@ -53,14 +53,4 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
-  {{- if .Values.ingress.http.tls }}
-  tls:
-    {{- range .Values.ingress.http.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
 {{- end }}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.

tls key in ingress is duplicated: 

```
spec:
  tls:
    - hosts:
        - "***"
      secretName: ssl
  rules:
    - host: "***"
      http:
        paths: ...
  tls:
    - hosts:
        - "***"
      secretName: ssl
```