### PR TITLE
Wrap errors around cgroups

### DIFF
--- a/perforator/agent/collector/pkg/cgroups/tracker.go
+++ b/perforator/agent/collector/pkg/cgroups/tracker.go
@@ -296,7 +296,7 @@ func (t *Tracker) AddCgroup(newCgroup *TrackedCgroup, reopenEventIfExists bool) 
 
 	cgroupID, err := t.nameCache.addCgroup(newCgroup.Name)
 	if err != nil {
-		return err
+		return fmt.Errorf("adding cgroup %s to name cache: %w", newCgroup.Name, err)
 	}
 
 	mapsLocked := true
@@ -327,7 +327,7 @@ func (t *Tracker) AddCgroup(newCgroup *TrackedCgroup, reopenEventIfExists bool) 
 
 		err = newCgroup.Event.Open(cgrp.name, cgrp.id)
 		if err != nil {
-			return err
+			return fmt.Errorf("opening cgroup event for %s: %w", newCgroup.Name, err)
 		}
 		cgrp.event.Close()
 		cgrp.event = newCgroup.Event
@@ -403,14 +403,14 @@ func (t *Tracker) TrackCgroups(cgrps []*TrackedCgroup) error {
 	for _, name := range deletedCgroups {
 		err := t.Delete(name)
 		if err != nil {
-			return err
+			return fmt.Errorf("deleting cgroup %s: %w", name, err)
 		}
 	}
 
 	for _, cgrp := range cgrps {
 		err := t.AddCgroup(cgrp, false)
 		if err != nil {
-			return err
+			return fmt.Errorf("adding cgroup %s: %w", cgrp.Name, err)
 		}
 	}
 

--- a/perforator/agent/collector/pkg/profiler/cgroupevent.go
+++ b/perforator/agent/collector/pkg/profiler/cgroupevent.go
@@ -2,10 +2,10 @@ package profiler
 
 import (
 	"fmt"
-	"github.com/yandex/perforator/library/go/co
+
 	"github.com/yandex/perforator/library/go/core/log"
 	"github.com/yandex/perforator/perforator/agent/collector/pkg/cgroups"
-	"fmt"
+	"github.com/yandex/perforator/perforator/agent/collector/pkg/machine"
 )
 
 type CgroupConfig struct {

--- a/perforator/agent/collector/pkg/profiler/cgroupevent.go
+++ b/perforator/agent/collector/pkg/profiler/cgroupevent.go
@@ -1,9 +1,11 @@
 package profiler
 
 import (
+	"fmt"
+	"github.com/yandex/perforator/library/go/co
 	"github.com/yandex/perforator/library/go/core/log"
 	"github.com/yandex/perforator/perforator/agent/collector/pkg/cgroups"
-	"github.com/yandex/perforator/perforator/agent/collector/pkg/machine"
+	"fmt"
 )
 
 type CgroupConfig struct {
@@ -50,7 +52,7 @@ func (t *trackedCgroup) Open(name string, freezerCgroupID uint64) error {
 
 	err := t.bpf.AddTracedCgroup(freezerCgroupID)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to add cgroup %q with id %d to eBPF maps: %w", name, freezerCgroupID, err)
 	}
 
 	t.freezerCgroupID = freezerCgroupID

--- a/perforator/agent/collector/pkg/profiler/pods_cgroup_tracker.go
+++ b/perforator/agent/collector/pkg/profiler/pods_cgroup_tracker.go
@@ -152,7 +152,7 @@ func (t *PodsCgroupTracker) rebuildWorkloadInfo(pods []deploysystemmodel.Pod) {
 func (t *PodsCgroupTracker) refreshCgroups(ctx context.Context) ([]*CgroupConfig, error) {
 	pods, err := t.podsLister.List(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing pods: %w", err)
 	}
 
 	t.l.Info("Found pods", log.Int("count", len(pods)))
@@ -300,10 +300,13 @@ func newPodsCgroupTracker(c *config.PodsDeploySystemConfig, l log.Logger, cgroup
 func (p *Profiler) updatePodsCgroups(ctx context.Context) error {
 	cgroups, err := p.podsCgroupTracker.refreshCgroups(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("refreshing cgroups: %w", err)
 	}
 
-	return p.TraceCgroups(cgroups)
+	if err := p.TraceCgroups(cgroups); err != nil {
+		return fmt.Errorf("tracing cgroups: %w", err)
+	}
+	return nil
 }
 
 func (p *Profiler) runPodsCgroupTracker(ctx context.Context) error {

--- a/perforator/agent/collector/pkg/profiler/profiler.go
+++ b/perforator/agent/collector/pkg/profiler/profiler.go
@@ -960,7 +960,10 @@ func (p *Profiler) TraceCgroups(configs []*CgroupConfig) error {
 		)
 	}
 
-	return p.cgroups.TrackCgroups(trackedCgroups)
+	if err := p.cgroups.TrackCgroups(trackedCgroups); err != nil {
+		return fmt.Errorf("tracking cgroups: %w", err)
+	}
+	return nil
 }
 
 func (p *Profiler) SetDebugMode(debug bool) (err error) {


### PR DESCRIPTION
We've had a few broken cgroups in our cluster (kubelet returned some pods as running, but their cgroups were long gone by then), and debugging the issue by the existing errors and logs proved hard. I've added a few error wrappings around the path that leads to a cgroup tracker worker failure to find issues like this easier in the future.