### PR TITLE
Use self-hosted runners

### DIFF
--- a/.github/workflows/postcommit.yaml
+++ b/.github/workflows/postcommit.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   ya:
    name: Postcommit checks
-   runs-on: self-hosted
+   runs-on: [self-hosted, auto-provisioned]
    steps:
     - uses: actions/checkout@v4
     - uses: tespkg/actions-cache@91b54a6e03abb8fcec12d3743633d23a1cfcd269

--- a/.github/workflows/postcommit.yaml
+++ b/.github/workflows/postcommit.yaml
@@ -2,10 +2,11 @@ on:
   push:
     branches: 
       - main
+      - users/MikailBag/ci-self-hosted
 jobs:
   ya:
    name: Postcommit checks
-   runs-on: ubuntu-24.04
+   runs-on: self-hosted
    steps:
     - uses: actions/checkout@v4
     - uses: tespkg/actions-cache@91b54a6e03abb8fcec12d3743633d23a1cfcd269

--- a/.github/workflows/postcommit.yaml
+++ b/.github/workflows/postcommit.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches: 
       - main
-      - users/MikailBag/ci-self-hosted
 jobs:
   ya:
    name: Postcommit checks


### PR DESCRIPTION
Currently we use GitHub-hosted runners, which are not big enough to satisfy our requirements (esp. when it comes to disk space).