### PR TITLE
Update CI postcommit job

### DIFF
--- a/.github/workflows/postcommit.yaml
+++ b/.github/workflows/postcommit.yaml
@@ -21,5 +21,5 @@ jobs:
           v1-
         path: ~/.ya/build
     - name: Run ya make
-      run: ./ya make ./perforator -DCI=github --gc -r --musl
+      run: ./ya test ./perforator -DCI=github --gc -r --musl -DCONSISTENT_BUILD=yes -DCONSISTENT_DEBUG=yes -T
 

--- a/.github/workflows/postcommit.yaml
+++ b/.github/workflows/postcommit.yaml
@@ -1,7 +1,8 @@
 on:
   push:
-    branches: 
+    branches:
       - main
+      - users/MikailBag/ci-test
 jobs:
   ya:
    name: Postcommit checks

--- a/.github/workflows/postcommit.yaml
+++ b/.github/workflows/postcommit.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - users/MikailBag/ci-test
 jobs:
   ya:
    name: Postcommit checks
@@ -23,7 +22,4 @@ jobs:
         path: ~/.ya/build
     - name: Run ya make
       run: ./ya test ./perforator -DCI=github --gc -r --musl -DCONSISTENT_BUILD=yes -DCONSISTENT_DEBUG=yes -T
-    - uses: actions/upload-artifact@v4
-      with:
-        name: temp-debug
-        path: /home/runner/actions_runner/_work/perforator/perforator/perforator/agent/collector/pkg/cgroups/gotest/test-results/gotest/testing_out_stuff
+

--- a/.github/workflows/postcommit.yaml
+++ b/.github/workflows/postcommit.yaml
@@ -23,4 +23,7 @@ jobs:
         path: ~/.ya/build
     - name: Run ya make
       run: ./ya test ./perforator -DCI=github --gc -r --musl -DCONSISTENT_BUILD=yes -DCONSISTENT_DEBUG=yes -T
-
+    - uses: actions/upload-artifact@v4
+      with:
+        name: temp-debug
+        path: /home/runner/actions_runner/_work/perforator/perforator/perforator/agent/collector/pkg/cgroups/gotest/test-results/gotest/testing_out_stuff


### PR DESCRIPTION
We did not run our tests in CI because of resource constraints. Now this is no longer a problem, so we start running all tests as well.

Additionally this patch adds CONSISTENT_BUILD and CONSISTENT_DEBUG flags as a step towards reproducible builds.