### PR TITLE
fix build error TS2742

### DIFF
--- a/perforator/ui/app/src/providers/RouterProvider/router.tsx
+++ b/perforator/ui/app/src/providers/RouterProvider/router.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../pages';
 
 
-export const getRouter = (pageProps: PageProps) => {
+export const getRouter = (pageProps: PageProps): ReturnType<typeof createBrowserRouter> => {
     const makePage = (page: PageComponent, title: Optional<string>) => (
         <PageContainer
             page={page}


### PR DESCRIPTION
I am not a TypeScript developer, so not 100% sure whether fix correct
```
command (pid: 579661) /home/sse4/.ya/tools/v4/9095799934/bin/python3 /home/sse4/projects/develop/dockerfiles/perforator/perforator/ui/union/build.py --curdir /home/sse4/projects/develop/dockerfiles/perforator/perforator/ui/union --bindir /home/sse4/.ya/build/build_root/hb7p/0010d5/perforator/ui/union --node-dir /home/sse4/.ya/tools/v4/7633866901 --pnpm-dir /home/sse4/.ya/tools/v4/9596164439 failed with exit code 1 in /home/sse4/.ya/build/build_root/hb7p/0010d5
Traceback (most recent call last):
  File "python3", line 92, in <module>
  File "python3", line 66, in main
  File "/ix/store/UQUIM6vDHFTR5xuJbhVaz1-lib-python-3-12/lib/python3.12/runpy.py", line 287, in run_path
  File "/ix/store/UQUIM6vDHFTR5xuJbhVaz1-lib-python-3-12/lib/python3.12/runpy.py", line 98, in _run_module_code
  File "/ix/store/UQUIM6vDHFTR5xuJbhVaz1-lib-python-3-12/lib/python3.12/runpy.py", line 88, in _run_code
  File "/home/sse4/projects/develop/dockerfiles/perforator/perforator/ui/union/build.py", line 68, in <module>
    main()
  File "/home/sse4/projects/develop/dockerfiles/perforator/perforator/ui/union/build.py", line 60, in main
    run_command([node, pnpm, 'run', 'build'])
  File "/home/sse4/projects/develop/dockerfiles/perforator/perforator/ui/union/build.py", line 33, in run_command
    raise RuntimeError(message)
RuntimeError: Process `<Popen: returncode: 2 args: ['/home/sse4/.ya/tools/v4/7633866901/node', '/ho...>` exited with code $2

stderr:


stdout:

> perforator@0.0.0 build /home/sse4/.ya/build/build_root/hb7p/0010d5/perforator/ui/union/ui/app
> tsc && vite build

src/providers/RouterProvider/router.tsx(17,14): error TS2742: The inferred type of 'getRouter' cannot be named without a reference to '.pnpm/@remix-run+router@1.15.3/node_modules/@remix-run/router'. This is likely not portable. A type annotation is necessary.
 ELIFECYCLE  Command failed with exit code 2.


cwd: /home/sse4/.ya/build/build_root/hb7p/0010d5/perforator/ui/union/ui/app
Failed
```