### PR TITLE
Removed std::move on return

### DIFF
--- a/perforator/symbolizer/lib/symbolize/symbolizer.cpp
+++ b/perforator/symbolizer/lib/symbolize/symbolizer.cpp
@@ -114,7 +114,7 @@ std::string CleanupFunctionName(std::string&& name) {
         }
     }
 
-    return std::move(name);
+    return name;
 }
 
 TCodeSymbolizer::TCodeSymbolizer()


### PR DESCRIPTION
Bad practice to use std::move on return. May prevent some optimizations and return value is rvalue anyway