### PR TITLE
Remove `--tls-ca` from migrate clickhouse because is not supported

### DIFF
--- a/perforator/deploy/kubernetes/helm/perforator/Chart.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
 type: application
 
 # See releases.md for changelog
-version: 0.2.10
+version: 0.2.11
 
 # Perforator version installed by default.
 # It can be overriden via Helm values.

--- a/perforator/deploy/kubernetes/helm/perforator/templates/migrate/job-ch.yaml
+++ b/perforator/deploy/kubernetes/helm/perforator/templates/migrate/job-ch.yaml
@@ -19,13 +19,6 @@
   {{- if or .Values.databases.clickhouse.tls.insecureSkipVerify .Values.databases.clickhouse.insecure }}
     {{- $tlsOpts = printf "%s --tls-trust-all" $tlsOpts }}
   {{- end }}
-  
-  {{- $caCertPath := include "perforator.clickhouse.tlsCACert" . }}
-  {{- if $caCertPath }}
-    {{- $tlsOpts = printf "%s --tls-ca %s" $tlsOpts $caCertPath }}
-  {{- else if .Values.databases.clickhouse.ca_cert_path }}
-    {{- $tlsOpts = printf "%s --tls-ca %s" $tlsOpts .Values.databases.clickhouse.ca_cert_path }}
-  {{- end }}
 {{- else }}
   {{- $tlsOpts = " --plaintext" }}
 {{- end }}

--- a/perforator/deploy/kubernetes/helm/releases.md
+++ b/perforator/deploy/kubernetes/helm/releases.md
@@ -21,6 +21,11 @@ Internal changes:
 
 1: If you are sending patch to GitHub, specify PR. Otherwise (if you are sending patch to internal monorepo), leave unset and then specify Git commit.
 -->
+# 0.2.11
+
+Fixes:
++ Remove `--tls-ca` from migrate clickhouse because [is not supported for clickhouse](https://github.com/yandex/perforator/blob/main/perforator/cmd/migrate/main.go#L269)
+
 # 0.2.10
 
 Enhancements:


### PR DESCRIPTION
Ch migrations not started, if tlsCA start