### PR TITLE
fix: remove incorrect Py_DECREF after PyList_SetItem

### DIFF
--- a/contrib/tools/cython/Cython/Utility/CythonFunction.c
+++ b/contrib/tools/cython/Cython/Utility/CythonFunction.c
@@ -523,7 +523,8 @@ __Pyx_CyFunction_get_is_coroutine_value(__pyx_CyFunctionObject *op) {
         PyList_SET_ITEM(fromlist, 0, marker);
 #else
         if (unlikely(PyList_SetItem(fromlist, 0, marker) < 0)) {
-            Py_DECREF(marker);
+            /* PyList_SetItem steals the reference to marker on both
+               success and failure, so we must not Py_DECREF it here. */
             Py_DECREF(fromlist);
             return NULL;
         }

--- a/contrib/tools/cython_py2/Cython/Utility/CythonFunction.c
+++ b/contrib/tools/cython_py2/Cython/Utility/CythonFunction.c
@@ -450,7 +450,8 @@ __Pyx_CyFunction_get_is_coroutine(__pyx_CyFunctionObject *op, void *context) {
         PyList_SET_ITEM(fromlist, 0, marker);
 #else
         if (unlikely(PyList_SetItem(fromlist, 0, marker) < 0)) {
-            Py_DECREF(marker);
+            /* PyList_SetItem steals the reference to marker on both
+               success and failure, so we must not Py_DECREF it here. */
             Py_DECREF(fromlist);
             return NULL;
         }


### PR DESCRIPTION
## Problem

`PyList_SetItem()` steals a reference to its third argument — even when the call fails. The current error path calls `Py_DECREF(marker)` after a failed `PyList_SetItem()`, which double-releases the reference since ownership was already transferred.

This is a use-after-free that can cause undefined behavior (crash, memory corruption) depending on allocator state and GC timing.

## Fix

Removed the incorrect `Py_DECREF(marker)` in both the `cython` and `cython_py2` copies of `CythonFunction.c`, and added a comment explaining the reference-stealing semantics for future maintainers.

The `Py_DECREF(fromlist)` is retained since `fromlist` still needs to be cleaned up.

Fixes #106